### PR TITLE
Update Lambda function runtimes to resolve deployment issue

### DIFF
--- a/rekognition-pipeline/lib/rekognition-pipeline-stack.ts
+++ b/rekognition-pipeline/lib/rekognition-pipeline-stack.ts
@@ -87,7 +87,7 @@ export class RekognitionPipelineStack extends cdk.Stack {
     // Helper Layer with helper functions
     const helperLayer = new lambda.LayerVersion(this, 'HelperLayer', {
       code: lambda.Code.fromAsset('lambda/helper'),
-      compatibleRuntimes: [lambda.Runtime.PYTHON_3_7],
+      compatibleRuntimes: [lambda.Runtime.PYTHON_3_9],
       license: 'Apache-2.0',
       description: 'Helper layer.',
     });
@@ -96,7 +96,7 @@ export class RekognitionPipelineStack extends cdk.Stack {
 
     // S3 Event processor
     const s3Processor = new lambda.Function(this, 'S3Processor', {
-      runtime: lambda.Runtime.PYTHON_3_7,
+      runtime: lambda.Runtime.PYTHON_3_9,
       code: lambda.Code.fromAsset('lambda/s3processor'),
       handler: 'lambda_function.lambda_handler',
       timeout: cdk.Duration.seconds(30),
@@ -139,7 +139,7 @@ export class RekognitionPipelineStack extends cdk.Stack {
 
     // S3 Batch Operations Event processor 
     const s3BatchProcessor = new lambda.Function(this, 'S3BatchProcessor', {
-      runtime: lambda.Runtime.PYTHON_3_7,
+      runtime: lambda.Runtime.PYTHON_3_9,
       code: lambda.Code.fromAsset('lambda/s3batchprocessor'),
       handler: 'lambda_function.lambda_handler',
       timeout: cdk.Duration.seconds(30),
@@ -164,7 +164,7 @@ export class RekognitionPipelineStack extends cdk.Stack {
 
     // Item processor (Router to Sync/Async Pipeline)
     const itemProcessor = new lambda.Function(this, 'TaskProcessor', {
-      runtime: lambda.Runtime.PYTHON_3_7,
+      runtime: lambda.Runtime.PYTHON_3_9,
       code: lambda.Code.fromAsset('lambda/itemprocessor'),
       handler: 'lambda_function.lambda_handler',
       timeout: cdk.Duration.seconds(900),
@@ -189,7 +189,7 @@ export class RekognitionPipelineStack extends cdk.Stack {
 
     // Sync Jobs Processor (Process jobs using sync APIs)
     const syncProcessor = new lambda.Function(this, 'SyncProcessor', {
-      runtime: lambda.Runtime.PYTHON_3_7,
+      runtime: lambda.Runtime.PYTHON_3_9,
       code: lambda.Code.fromAsset('lambda/syncprocessor'),
       handler: 'lambda_function.lambda_handler',
       reservedConcurrentExecutions: 1,
@@ -222,7 +222,7 @@ export class RekognitionPipelineStack extends cdk.Stack {
 
     // Async Job Processor (Start jobs using Async APIs)
     const asyncProcessor = new lambda.Function(this, 'ASyncProcessor', {
-      runtime: lambda.Runtime.PYTHON_3_7,
+      runtime: lambda.Runtime.PYTHON_3_9,
       code: lambda.Code.fromAsset('lambda/asyncprocessor'),
       handler: 'lambda_function.lambda_handler',
       reservedConcurrentExecutions: 1,
@@ -267,7 +267,7 @@ export class RekognitionPipelineStack extends cdk.Stack {
 
     // Async Jobs Results Processor
     const jobResultProcessor = new lambda.Function(this, 'JobResultProcessor', {
-      runtime: lambda.Runtime.PYTHON_3_7,
+      runtime: lambda.Runtime.PYTHON_3_9,
       code: lambda.Code.fromAsset('lambda/jobresultprocessor'),
       handler: 'lambda_function.lambda_handler',
       memorySize: 2000,
@@ -305,7 +305,7 @@ export class RekognitionPipelineStack extends cdk.Stack {
       description: 'Creates folders in S3 bucket for different Rekognition APIs',
       handler: 'index.lambda_handler',
       timeout: cdk.Duration.seconds(60),
-      runtime: lambda.Runtime.PYTHON_3_7,
+      runtime: lambda.Runtime.PYTHON_3_9,
       environment: {
           CONTENT_BUCKET: contentBucket.bucketName,
           EXISTING_CONTENT_BUCKET: existingContentBucket.bucketName,


### PR DESCRIPTION
The deployment of the RekognitionPipelineStack was failing due to the use of the unsupported Python 3.7 runtime for Lambda functions. This commit updates the runtime to Python 3.9 for the affected Lambda functions, including S3Processor, S3BatchProcessor, TaskProcessor, and JobResultProcessor.

The Python runtime version has been changed from lambda.Runtime.PYTHON_3_7 to lambda.Runtime.PYTHON_3_9 in the rekognition-pipeline-stack.ts file. This change ensures compatibility with the current AWS Lambda runtime requirements and allows for successful deployment of the stack.

Resolves the deployment error: "The runtime parameter of python3.7 is no longer supported for creating or updating AWS Lambda functions."

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
